### PR TITLE
Add CrateDB dialect in order to support Arrays, Maps and Struct data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>5.4.0-SNAPSHOT</version>
+        <version>5.1.3</version>
     </parent>
 
     <groupId>io.confluent</groupId>
@@ -60,6 +60,7 @@
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <sqlite-jdbc.version>3.25.2</sqlite-jdbc.version>
         <postgresql.version>9.4-1206-jdbc41</postgresql.version>
+        <cratedb.version>2.5.1</cratedb.version>
         <jtds.driver.version>1.3.1</jtds.driver.version>
         <licenses.name>Confluent Community License</licenses.name>
         <licenses.version>${project.version}</licenses.version>
@@ -73,6 +74,23 @@
             <id>confluent</id>
             <name>Confluent</name>
             <url>${confluent.maven.repo}</url>
+        </repository>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>bintray</id>
+            <name>bintray</name>
+            <url>http://dl.bintray.com/crate/crate</url>
+        </repository>
+        <repository>
+          <id>central</id>
+          <name>Central Repository</name>
+          <url>https://repo.maven.apache.org/maven2</url>
+          <layout>default</layout>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
         </repository>
     </repositories>
 
@@ -94,6 +112,12 @@
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <version>${postgresql.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.crate</groupId>
+            <artifactId>crate-jdbc</artifactId>
+            <version>${cratedb.version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
@@ -211,6 +235,7 @@
                                 <tag>sql</tag>
                                 <tag>mysql</tag>
                                 <tag>postgresql</tag>
+                                <tag>cratedb</tag>
                                 <tag>oracle</tag>
                                 <tag>sql server</tag>
                                 <tag>db2</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>common</artifactId>
-        <version>5.1.3</version>
+        <version>5.4.0-SNAPSHOT</version>
     </parent>
 
     <groupId>io.confluent</groupId>
@@ -82,15 +82,6 @@
             <id>bintray</id>
             <name>bintray</name>
             <url>http://dl.bintray.com/crate/crate</url>
-        </repository>
-        <repository>
-          <id>central</id>
-          <name>Central Repository</name>
-          <url>https://repo.maven.apache.org/maven2</url>
-          <layout>default</layout>
-          <snapshots>
-            <enabled>false</enabled>
-          </snapshots>
         </repository>
     </repositories>
 

--- a/src/main/java/io/confluent/connect/jdbc/dialect/CrateDatabaseDialect.java
+++ b/src/main/java/io/confluent/connect/jdbc/dialect/CrateDatabaseDialect.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.dialect;
+
+import io.confluent.connect.jdbc.dialect.DatabaseDialectProvider.SubprotocolBasedProvider;
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import io.confluent.connect.jdbc.source.ColumnMapping;
+import io.confluent.connect.jdbc.util.ColumnDefinition;
+import io.confluent.connect.jdbc.util.ColumnId;
+import io.confluent.connect.jdbc.util.ExpressionBuilder;
+import io.confluent.connect.jdbc.util.ExpressionBuilder.Transform;
+import io.confluent.connect.jdbc.util.IdentifierRules;
+import io.confluent.connect.jdbc.util.TableId;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.data.Date;
+import org.apache.kafka.connect.data.Time;
+import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.data.Decimal;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.Field;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.ConnectException;
+
+import java.nio.ByteBuffer;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Types;
+import java.util.Collection;
+import java.util.List;
+import java.util.StringJoiner;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+
+
+/**
+ * A {@link DatabaseDialect} for CrateDB.
+ */
+public class CrateDatabaseDialect extends GenericDatabaseDialect {
+
+  /**
+   * The provider for {@link CrateDatabaseDialect}.
+   */
+  public static class Provider extends SubprotocolBasedProvider {
+    public Provider() {
+      super(CrateDatabaseDialect.class.getSimpleName(), "cratedb");
+    }
+
+    @Override
+    public DatabaseDialect create(AbstractConfig config) {
+      return new CrateDatabaseDialect(config);
+    }
+  }
+
+  private static final String OBJECT_TYPE_NAME = "object";
+
+  /**
+   * Create a new dialect instance with the given connector configuration.
+   *
+   * @param config the connector configuration; may not be null
+   */
+  public CrateDatabaseDialect(AbstractConfig config) {
+    super(config, new IdentifierRules(".", "\"", "\""));
+  }
+
+  /**
+   * Perform any operations on a {@link PreparedStatement} before it is used. This is called from
+   * the {@link #createPreparedStatement(Connection, String)} method after the statement is
+   * created but before it is returned/used.
+   *
+   * <p>This method sets the {@link PreparedStatement#setFetchDirection(int) fetch direction}
+   * to {@link ResultSet#FETCH_FORWARD forward} as an optimization for the driver to allow it to
+   * scroll more efficiently through the result set and prevent out of memory errors.
+   *
+   * @param stmt the prepared statement; never null
+   * @throws SQLException the error that might result from initialization
+   */
+  @Override
+  protected void initializePreparedStatement(PreparedStatement stmt) throws SQLException {
+    log.trace("Initializing PreparedStatement fetch direction to FETCH_FORWARD for '{}'", stmt);
+    stmt.setFetchDirection(ResultSet.FETCH_FORWARD);
+  }
+
+  @Override
+  public String addFieldToSchema(ColumnDefinition columnDefn, SchemaBuilder builder) {
+    final String fieldName = fieldNameFor(columnDefn);
+    switch (columnDefn.type()) {
+      case Types.BIT: {
+        boolean optional = columnDefn.isOptional();
+        int numBits = columnDefn.precision();
+        Schema schema;
+        if (numBits <= 1) {
+          schema = optional ? Schema.OPTIONAL_BOOLEAN_SCHEMA : Schema.BOOLEAN_SCHEMA;
+        } else if (numBits <= 8) {
+          schema = optional ? Schema.OPTIONAL_INT8_SCHEMA : Schema.INT8_SCHEMA;
+        } else {
+          schema = optional ? Schema.OPTIONAL_BYTES_SCHEMA : Schema.BYTES_SCHEMA;
+        }
+        builder.field(fieldName, schema);
+        return fieldName;
+      }
+      case Types.OTHER: {
+        // Some of these types will have fixed size, but we drop this from the schema conversion
+        // since only fixed byte arrays can have a fixed size
+        if (isObjectType(columnDefn)) {
+          builder.field(
+              fieldName,
+              columnDefn.isOptional() ? Schema.OPTIONAL_STRING_SCHEMA : Schema.STRING_SCHEMA
+          );
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    // Delegate for the remaining logic
+    return super.addFieldToSchema(columnDefn, builder);
+  }
+
+  @Override
+  public ColumnConverter createColumnConverter(
+      ColumnMapping mapping
+  ) {
+    // First handle any PostgreSQL-specific types
+    ColumnDefinition columnDefn = mapping.columnDefn();
+    int col = mapping.columnNumber();
+    switch (columnDefn.type()) {
+      case Types.BIT: {
+        // PostgreSQL allows variable length bit strings, but when length is 1 then the driver
+        // returns a 't' or 'f' string value to represent the boolean value, so we need to handle
+        // this as well as lengths larger than 8.
+        final int numBits = columnDefn.precision();
+        if (numBits <= 1) {
+          return rs -> rs.getBoolean(col);
+        } else if (numBits <= 8) {
+          // Do this for consistency with earlier versions of the connector
+          return rs -> rs.getByte(col);
+        }
+        return rs -> rs.getBytes(col);
+      }
+      case Types.OTHER: {
+        if (isObjectType(columnDefn)) {
+          return rs -> rs.getString(col);
+        }
+        break;
+      }
+      default:
+        break;
+    }
+
+    // Delegate for the remaining logic
+    return super.createColumnConverter(mapping);
+  }
+
+  protected boolean isObjectType(ColumnDefinition columnDefn) {
+    String typeName = columnDefn.typeName();
+    return OBJECT_TYPE_NAME.equalsIgnoreCase(typeName);
+  }
+
+  @Override
+  protected String getSqlType(SinkRecordField field) {
+    String type = getSchemaType(field.schema());
+    if (type.isEmpty()) {
+      return super.getSqlType(field);
+    } else {
+      return type;
+    }
+  }
+
+  private String getSchemaType(Schema schema) {
+    if (schema.name() != null) {
+      switch (schema.name()) {
+        case Decimal.LOGICAL_NAME:
+          return "FLOAT";
+        case Date.LOGICAL_NAME:
+        case Time.LOGICAL_NAME:
+        case Timestamp.LOGICAL_NAME:
+          return "TIMESTAMP";
+        default:
+      }
+    }
+    switch (schema.type()) {
+      case INT8:
+      case INT16:
+        return "SHORT";
+      case INT32:
+        return "INTEGER";
+      case INT64:
+        return "LONG";
+      case FLOAT32:
+      case FLOAT64:
+        return "FLOAT";
+      case BOOLEAN:
+        return "BOOLEAN";
+      case STRING:
+        return "STRING";
+      case BYTES:
+        return "BYTE";
+      case STRUCT:
+        StringBuilder definition = new StringBuilder("OBJECT(STRICT) as (");
+        List<Field> fields = schema.fields();
+        StringJoiner fieldsJoiner = new StringJoiner(", ");
+        for (Field f : fields) {
+          fieldsJoiner.add(f.name() + " " + getSchemaType(f.schema()));
+        }
+        definition.append(fieldsJoiner.toString());
+        definition.append(")");
+        return definition.toString();
+      case MAP:
+        return "OBJECT(DYNAMIC)";
+      case ARRAY:
+        return "ARRAY(" + getSchemaType(schema.valueSchema()) + ")";
+      default:
+        return "";
+    }
+  }
+
+  @Override
+  public void bindField(
+          PreparedStatement statement,
+          int index,
+          Schema schema,
+          Object value
+  ) throws SQLException {
+    if (value == null) {
+      statement.setObject(index, null);
+    } else {
+      boolean bound = maybeBindLogical(statement, index, schema, value);
+      if (!bound) {
+        bound = maybeBindPrimitive(statement, index, schema, value);
+      }
+      if (!bound) {
+        throw new ConnectException("Unsupported source data type: " + schema.type());
+      }
+    }
+  }
+
+  @Override
+  protected boolean maybeBindPrimitive(
+          PreparedStatement statement,
+          int index,
+          Schema schema,
+          Object value
+  ) throws SQLException {
+    switch (schema.type()) {
+      case INT8:
+        statement.setByte(index, (Byte) value);
+        break;
+      case INT16:
+        statement.setShort(index, (Short) value);
+        break;
+      case INT32:
+        statement.setInt(index, (Integer) value);
+        break;
+      case INT64:
+        statement.setLong(index, (Long) value);
+        break;
+      case FLOAT32:
+        statement.setFloat(index, (Float) value);
+        break;
+      case FLOAT64:
+        statement.setDouble(index, (Double) value);
+        break;
+      case BOOLEAN:
+        statement.setBoolean(index, (Boolean) value);
+        break;
+      case STRING:
+        statement.setString(index, (String) value);
+        break;
+      case STRUCT:
+        statement.setObject(index, structToMap((Struct) value));
+        break;
+      case MAP:
+        statement.setObject(index, value);
+        break;
+      case ARRAY:
+        statement.setArray(index, statement.getConnection().createArrayOf(
+            getSchemaType(schema.valueSchema()).toLowerCase(),
+            ((ArrayList) value).toArray())
+        );
+        break;
+      case BYTES:
+        final byte[] bytes;
+        if (value instanceof ByteBuffer) {
+          final ByteBuffer buffer = ((ByteBuffer) value).slice();
+          bytes = new byte[buffer.remaining()];
+          buffer.get(bytes);
+        } else {
+          bytes = (byte[]) value;
+        }
+        statement.setBytes(index, bytes);
+        break;
+      default:
+        return false;
+    }
+    return true;
+  }
+
+  public Map<String, Object> structToMap(Struct struct) {
+    Map<String, Object> map = new HashMap<>();
+    for (Field field : struct.schema().fields()) {
+      if (field.schema().type() == Schema.Type.STRUCT) {
+        map.put(field.name(), structToMap((Struct) struct.get(field)));
+      } else {
+        map.put(field.name(), struct.get(field));
+      }
+    }
+    return map;
+  }
+
+  @Override
+  public String buildUpsertQueryStatement(
+      TableId table,
+      Collection<ColumnId> keyColumns,
+      Collection<ColumnId> nonKeyColumns
+  ) {
+    final Transform<ColumnId> transform = (builder, col) -> {
+      builder.appendColumnName(col.name())
+             .append("=EXCLUDED.")
+             .appendColumnName(col.name());
+    };
+
+    ExpressionBuilder builder = expressionBuilder();
+    builder.append("INSERT INTO ");
+    builder.append(table);
+    builder.append(" (");
+    builder.appendList()
+           .delimitedBy(",")
+           .transformedBy(ExpressionBuilder.columnNames())
+           .of(keyColumns, nonKeyColumns);
+    builder.append(") VALUES (");
+    builder.appendMultiple(",", "?", keyColumns.size() + nonKeyColumns.size());
+    builder.append(") ON CONFLICT (");
+    builder.appendList()
+           .delimitedBy(",")
+           .transformedBy(ExpressionBuilder.columnNames())
+           .of(keyColumns);
+    if (nonKeyColumns.isEmpty()) {
+      builder.append(") DO NOTHING");
+    } else {
+      builder.append(") DO UPDATE SET ");
+      builder.appendList()
+              .delimitedBy(",")
+              .transformedBy(transform)
+              .of(nonKeyColumns);
+    }
+    return builder.toString();
+  }
+
+  @Override
+  public String buildCreateTableStatement(
+      TableId table,
+      Collection<SinkRecordField> fields
+  ) {
+    ExpressionBuilder builder = expressionBuilder();
+
+    final List<String> pkFieldNames = extractPrimaryKeyFieldNames(fields);
+    builder.append("CREATE TABLE ");
+    builder.append(table);
+    builder.append(" (");
+    writeColumnsSpec(builder, fields);
+    if (!pkFieldNames.isEmpty()) {
+      builder.append(",");
+      builder.append(System.lineSeparator());
+      builder.append("PRIMARY KEY(");
+      builder.appendList()
+          .delimitedBy(",")
+          .transformedBy(ExpressionBuilder.quote())
+          .of(pkFieldNames);
+      builder.append(")");
+    }
+    builder.append(")");
+    return builder.toString();
+  }
+
+  protected void writeColumnsSpec(
+      ExpressionBuilder builder,
+      Collection<SinkRecordField> fields
+  ) {
+    Transform<SinkRecordField> transform = (b, field) -> {
+      b.append(System.lineSeparator());
+      writeColumnSpec(b, field);
+    };
+    builder.appendList().delimitedBy(",").transformedBy(transform).of(fields);
+  }
+
+  protected void writeColumnSpec(
+      ExpressionBuilder builder,
+      SinkRecordField f
+  ) {
+    builder.appendColumnName(f.name());
+    builder.append(" ");
+    String sqlType = getSqlType(f);
+    builder.append(sqlType);
+    if (!isColumnOptional(f)) {
+      builder.append(" NOT NULL");
+    }
+  }
+
+}

--- a/src/main/java/io/confluent/connect/jdbc/sink/metadata/SinkRecordField.java
+++ b/src/main/java/io/confluent/connect/jdbc/sink/metadata/SinkRecordField.java
@@ -59,6 +59,10 @@ public class SinkRecordField {
     return isPrimaryKey;
   }
 
+  public Schema schema() {
+    return schema;
+  }
+
   @Override
   public String toString() {
     return "SinkRecordField{"

--- a/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
+++ b/src/main/resources/META-INF/services/io.confluent.connect.jdbc.dialect.DatabaseDialectProvider
@@ -9,3 +9,4 @@ io.confluent.connect.jdbc.dialect.SqlServerDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SapHanaDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.SybaseDatabaseDialect$Provider
 io.confluent.connect.jdbc.dialect.VerticaDatabaseDialect$Provider
+io.confluent.connect.jdbc.dialect.CrateDatabaseDialect$Provider

--- a/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/BaseDialectTest.java
@@ -375,6 +375,8 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     }
   }
 
+  /*   These tests are disabled, for the time being.
+
   @Test(expected = ConnectException.class)
   public void bindFieldStructUnsupported() throws SQLException {
     Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
@@ -392,6 +394,7 @@ public abstract class BaseDialectTest<T extends GenericDatabaseDialect> {
     Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
     dialect.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
+  */
 
   protected void assertSanitizedUrl(String url, String expectedSanitizedUrl) {
     assertEquals(expectedSanitizedUrl, dialect.sanitizedUrl(url));

--- a/src/test/java/io/confluent/connect/jdbc/dialect/CrateDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/CrateDatabaseDialectTest.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.jdbc.dialect;
+
+import io.confluent.connect.jdbc.sink.metadata.SinkRecordField;
+import io.confluent.connect.jdbc.util.QuoteMethod;
+import io.confluent.connect.jdbc.util.TableId;
+import org.apache.kafka.connect.data.*;
+import org.apache.kafka.connect.data.Schema.Type;
+import org.junit.Test;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+
+public class CrateDatabaseDialectTest extends BaseDialectTest<CrateDatabaseDialect> {
+
+  @Override
+  protected CrateDatabaseDialect createDialect() {
+    return new CrateDatabaseDialect(sourceConfigWithUrl("jdbc:crate://something"));
+  }
+
+  @Test
+  public void shouldMapPrimitiveSchemaTypeToSqlTypes() {
+    assertPrimitiveMapping(Type.INT8, "SHORT");
+    assertPrimitiveMapping(Type.INT16, "SHORT");
+    assertPrimitiveMapping(Type.INT32, "INTEGER");
+    assertPrimitiveMapping(Type.INT64, "LONG");
+    assertPrimitiveMapping(Type.FLOAT32, "FLOAT");
+    assertPrimitiveMapping(Type.FLOAT64, "FLOAT");
+    assertPrimitiveMapping(Type.BOOLEAN, "BOOLEAN");
+    assertPrimitiveMapping(Type.BYTES, "BYTE");
+    assertPrimitiveMapping(Type.STRING, "STRING");
+  }
+
+  @Test
+  public void shouldMapStructuredSchemaTypeToSqlTypes() {
+    assertStructuredMapping(SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA), Type.STRUCT, "OBJECT(STRICT) as (test BOOLEAN)");
+    assertStructuredMapping(SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA), Type.MAP,"OBJECT(DYNAMIC)");
+    assertStructuredMapping(SchemaBuilder.array(Schema.INT32_SCHEMA), Type.ARRAY, "ARRAY(INTEGER)");
+  }
+
+  private void assertStructuredMapping(SchemaBuilder schemaBuilder, Schema.Type expectedType, String expectedSqlType) {
+    Schema schema = schemaBuilder.build();
+    SinkRecordField field = new SinkRecordField(schema, schema.name(), false);
+    String sqlType = dialect.getSqlType(field);
+    assertEquals(expectedSqlType, sqlType);
+  }
+
+  @Test
+  public void shouldMapDecimalSchemaTypeToFloatSqlType() {
+    assertDecimalMapping(0, "FLOAT");
+    assertDecimalMapping(3, "FLOAT");
+    assertDecimalMapping(4, "FLOAT");
+    assertDecimalMapping(5, "FLOAT");
+  }
+
+  @Test
+  public void shouldMapDataTypes() {
+    verifyDataTypeMapping("SHORT", Schema.INT8_SCHEMA);
+    verifyDataTypeMapping("SHORT", Schema.INT16_SCHEMA);
+    verifyDataTypeMapping("INTEGER", Schema.INT32_SCHEMA);
+    verifyDataTypeMapping("LONG", Schema.INT64_SCHEMA);
+    verifyDataTypeMapping("FLOAT", Schema.FLOAT32_SCHEMA);
+    verifyDataTypeMapping("FLOAT", Schema.FLOAT64_SCHEMA);
+    verifyDataTypeMapping("BOOLEAN", Schema.BOOLEAN_SCHEMA);
+    verifyDataTypeMapping("STRING", Schema.STRING_SCHEMA);
+    verifyDataTypeMapping("BYTE", Schema.BYTES_SCHEMA);
+    verifyDataTypeMapping("FLOAT", Decimal.schema(0));
+    verifyDataTypeMapping("TIMESTAMP", Date.SCHEMA);
+    verifyDataTypeMapping("TIMESTAMP", Time.SCHEMA);
+    verifyDataTypeMapping("TIMESTAMP", Timestamp.SCHEMA);
+  }
+
+  @Test
+  public void shouldMapDateSchemaTypeToDateSqlType() {
+    assertDateMapping("TIMESTAMP");
+  }
+
+  @Test
+  public void shouldMapTimeSchemaTypeToTimeSqlType() {
+    assertTimeMapping("TIMESTAMP");
+  }
+
+  @Test
+  public void shouldMapTimestampSchemaTypeToTimestampSqlType() {
+    assertTimestampMapping("TIMESTAMP");
+  }
+
+  @Test
+  public void shouldBuildCreateQueryStatement() {
+    SinkRecordField f9 = new SinkRecordField(
+      SchemaBuilder.struct()
+              .field("test", Schema.BOOLEAN_SCHEMA)
+              .field("test2", Schema.STRING_SCHEMA)
+              .field("test3", SchemaBuilder.struct().field("testA", Schema.INT32_SCHEMA).build())
+            .build(),
+      "c9",
+      false);
+    SinkRecordField f10 = new SinkRecordField(
+            SchemaBuilder.array(Schema.STRING_SCHEMA),
+            "c10",
+            false);
+    SinkRecordField f11 = new SinkRecordField(
+            SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA),
+            "c11",
+            false);
+    List<SinkRecordField> extendedSinkRecordFields = new ArrayList<>(sinkRecordFields);
+    extendedSinkRecordFields.addAll(Arrays.asList(f9, f10, f11));
+
+    assertEquals(
+        "CREATE TABLE \"myTable\" (\n"
+            + "\"c1\" INTEGER NOT NULL,\n"
+            + "\"c2\" LONG NOT NULL,\n"
+            + "\"c3\" STRING NOT NULL,\n"
+            + "\"c4\" STRING,\n"
+            + "\"c5\" TIMESTAMP,\n"
+            + "\"c6\" TIMESTAMP,\n"
+            + "\"c7\" TIMESTAMP,\n"
+            + "\"c8\" FLOAT,\n"
+            + "\"c9\" OBJECT(STRICT) as (test BOOLEAN, test2 STRING, test3 OBJECT(STRICT) as (testA INTEGER)) NOT NULL,\n"
+            + "\"c10\" ARRAY(STRING) NOT NULL,\n"
+            + "\"c11\" OBJECT(DYNAMIC) NOT NULL,\n"
+            + "PRIMARY KEY(\"c1\"))",
+        dialect.buildCreateTableStatement(tableId, extendedSinkRecordFields)
+    );
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "CREATE TABLE myTable (\n"
+            + "c1 INTEGER NOT NULL,\n"
+            + "c2 LONG NOT NULL,\n"
+            + "c3 STRING NOT NULL,\n"
+            + "c4 STRING,\n"
+            + "c5 TIMESTAMP,\n"
+            + "c6 TIMESTAMP,\n"
+            + "c7 TIMESTAMP,\n"
+            + "c8 FLOAT,\n"
+            + "c9 OBJECT(STRICT) as (test BOOLEAN, test2 STRING, test3 OBJECT(STRICT) as (testA INTEGER)) NOT NULL,\n"
+            + "c10 ARRAY(STRING) NOT NULL,\n"
+            + "c11 OBJECT(DYNAMIC) NOT NULL,\n"
+            + "PRIMARY KEY(c1))",
+        dialect.buildCreateTableStatement(tableId, extendedSinkRecordFields)
+    );
+  }
+
+  @Test
+  public void shouldBuildAlterTableStatement() {
+    assertEquals(
+        Arrays.asList(
+            "ALTER TABLE \"myTable\" \n"
+            + "ADD \"c1\" INTEGER NOT NULL,\n"
+            + "ADD \"c2\" LONG NOT NULL,\n"
+            + "ADD \"c3\" STRING NOT NULL,\n"
+            + "ADD \"c4\" STRING,\n"
+            + "ADD \"c5\" TIMESTAMP,\n"
+            + "ADD \"c6\" TIMESTAMP,\n"
+            + "ADD \"c7\" TIMESTAMP,\n"
+            + "ADD \"c8\" FLOAT"
+        ),
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        Arrays.asList(
+            "ALTER TABLE myTable \n"
+            + "ADD c1 INTEGER NOT NULL,\n"
+            + "ADD c2 LONG NOT NULL,\n"
+            + "ADD c3 STRING NOT NULL,\n"
+            + "ADD c4 STRING,\n"
+            + "ADD c5 TIMESTAMP,\n"
+            + "ADD c6 TIMESTAMP,\n"
+            + "ADD c7 TIMESTAMP,\n"
+            + "ADD c8 FLOAT"
+        ),
+        dialect.buildAlterTable(tableId, sinkRecordFields)
+    );
+  }
+
+  @Test
+  public void shouldBuildUpsertStatement() {
+    assertEquals(
+        "INSERT INTO \"myTable\" (\"id1\",\"id2\",\"columnA\",\"columnB\"," +
+        "\"columnC\",\"columnD\") VALUES (?,?,?,?,?,?) ON CONFLICT (\"id1\"," +
+        "\"id2\") DO UPDATE SET \"columnA\"=EXCLUDED" +
+        ".\"columnA\",\"columnB\"=EXCLUDED.\"columnB\",\"columnC\"=EXCLUDED" +
+        ".\"columnC\",\"columnD\"=EXCLUDED.\"columnD\"",
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
+    );
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "INSERT INTO myTable (id1,id2,columnA,columnB," +
+        "columnC,columnD) VALUES (?,?,?,?,?,?) ON CONFLICT (id1," +
+        "id2) DO UPDATE SET columnA=EXCLUDED" +
+        ".columnA,columnB=EXCLUDED.columnB,columnC=EXCLUDED" +
+        ".columnC,columnD=EXCLUDED.columnD",
+        dialect.buildUpsertQueryStatement(tableId, pkColumns, columnsAtoD)
+    );
+  }
+
+  @Test
+  public void createOneColNoPk() {
+    verifyCreateOneColNoPk(
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "\"col1\" INTEGER NOT NULL)");
+  }
+
+  @Test
+  public void createOneColOnePk() {
+    verifyCreateOneColOnePk(
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "\"pk1\" INTEGER NOT NULL," +
+        System.lineSeparator() + "PRIMARY KEY(\"pk1\"))");
+  }
+
+  @Test
+  public void createThreeColTwoPk() {
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE \"myTable\" (" + System.lineSeparator() + "\"pk1\" INTEGER NOT NULL," +
+        System.lineSeparator() + "\"pk2\" INTEGER NOT NULL," + System.lineSeparator() +
+        "\"col1\" INTEGER NOT NULL," + System.lineSeparator() + "PRIMARY KEY(\"pk1\",\"pk2\"))");
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    verifyCreateThreeColTwoPk(
+        "CREATE TABLE myTable (" + System.lineSeparator() + "pk1 INTEGER NOT NULL," +
+        System.lineSeparator() + "pk2 INTEGER NOT NULL," + System.lineSeparator() +
+        "col1 INTEGER NOT NULL," + System.lineSeparator() + "PRIMARY KEY(pk1,pk2))");
+  }
+
+  @Test
+  public void alterAddOneCol() {
+    verifyAlterAddOneCol("ALTER TABLE \"myTable\" ADD \"newcol1\" INTEGER");
+  }
+
+  @Test
+  public void alterAddTwoCol() {
+    verifyAlterAddTwoCols(
+        "ALTER TABLE \"myTable\" " + System.lineSeparator() + "ADD \"newcol1\" INTEGER," +
+        System.lineSeparator() + "ADD \"newcol2\" INTEGER NOT NULL");
+  }
+
+  @Test
+  public void upsert() {
+    TableId customer = tableId("Customer");
+    assertEquals(
+        "INSERT INTO \"Customer\" (\"id\",\"name\",\"salary\",\"address\") " +
+         "VALUES (?,?,?,?) ON CONFLICT (\"id\") DO UPDATE SET \"name\"=EXCLUDED.\"name\"," +
+         "\"salary\"=EXCLUDED.\"salary\",\"address\"=EXCLUDED.\"address\"",
+        dialect.buildUpsertQueryStatement(
+            customer,
+            columns(customer, "id"),
+            columns(customer, "name", "salary", "address")
+        )
+    );
+
+    assertEquals(
+            "INSERT INTO \"Customer\" (\"id\",\"name\",\"salary\",\"address\") " +
+                    "VALUES (?,?,?,?) ON CONFLICT (\"id\",\"name\",\"salary\",\"address\") DO NOTHING",
+            dialect.buildUpsertQueryStatement(
+                    customer,
+                    columns(customer, "id", "name", "salary", "address"),
+                    columns(customer)
+            )
+    );
+
+    quoteIdentfiiers = QuoteMethod.NEVER;
+    dialect = createDialect();
+
+    assertEquals(
+        "INSERT INTO Customer (id,name,salary,address) " +
+        "VALUES (?,?,?,?) ON CONFLICT (id) DO UPDATE SET name=EXCLUDED.name," +
+        "salary=EXCLUDED.salary,address=EXCLUDED.address",
+        dialect.buildUpsertQueryStatement(
+            customer,
+            columns(customer, "id"),
+            columns(customer, "name", "salary", "address")
+        )
+    );
+
+    assertEquals(
+            "INSERT INTO Customer (id,name,salary,address) " +
+                    "VALUES (?,?,?,?) ON CONFLICT (id,name,salary,address) DO NOTHING",
+            dialect.buildUpsertQueryStatement(
+                    customer,
+                    columns(customer, "id", "name", "salary", "address"),
+                    columns(customer)
+            )
+    );
+  }
+
+  @Test
+  public void shouldSanitizeUrlWithoutCredentialsInProperties() {
+    assertSanitizedUrl(
+        "jdbc:crate://localhost/test?user=fred&ssl=true",
+        "jdbc:crate://localhost/test?user=fred&ssl=true"
+    );
+  }
+
+  @Test
+  public void shouldSanitizeUrlWithCredentialsInUrlProperties() {
+    assertSanitizedUrl(
+        "jdbc:crate://localhost/test?user=fred&password=secret&ssl=true",
+        "jdbc:crate://localhost/test?user=fred&password=****&ssl=true"
+    );
+  }
+
+}
+
+

--- a/src/test/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/Db2DatabaseDialectTest.java
@@ -19,10 +19,16 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 
 import io.confluent.connect.jdbc.util.QuoteMethod;
@@ -30,6 +36,7 @@ import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
 
 public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> {
 
@@ -361,5 +368,23 @@ public class Db2DatabaseDialectTest extends BaseDialectTest<Db2DatabaseDialect> 
   @Test
   public void testCheckConnectionQuery() {
     assertFalse(dialect.checkConnectionQuery().contains(";"));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldStructUnsupported() throws SQLException {
+    Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
+    dialect.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldArrayUnsupported() throws SQLException {
+    Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldMapUnsupported() throws SQLException {
+    Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/DerbyDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/DerbyDatabaseDialectTest.java
@@ -19,17 +19,24 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDialect> {
 
@@ -288,5 +295,23 @@ public class DerbyDatabaseDialectTest extends BaseDialectTest<DerbyDatabaseDiale
         "jdbc:derby:sample;password=toFetchAPail;user=jill",
         "jdbc:derby:sample;password=****;user=jill"
     );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldStructUnsupported() throws SQLException {
+    Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
+    dialect.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldArrayUnsupported() throws SQLException {
+    Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldMapUnsupported() throws SQLException {
+    Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/GenericDatabaseDialectTest.java
@@ -20,6 +20,7 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -29,6 +30,7 @@ import org.junit.Test;
 
 import java.math.BigDecimal;
 import java.sql.Connection;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Arrays;
@@ -57,6 +59,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
 
 public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseDialect> {
 
@@ -421,5 +424,23 @@ public class GenericDatabaseDialectTest extends BaseDialectTest<GenericDatabaseD
         "jdbc:acme:db/foo:100?password=****&key1=value1&key2=value2&key3=value3&"
         + "user=smith&password=****&other=value"
     );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldStructUnsupported() throws SQLException {
+    Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
+    dialect.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldArrayUnsupported() throws SQLException {
+    Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldMapUnsupported() throws SQLException {
+    Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/MySqlDatabaseDialectTest.java
@@ -19,16 +19,23 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDialect> {
 
@@ -252,5 +259,23 @@ public class MySqlDatabaseDialectTest extends BaseDialectTest<MySqlDatabaseDiale
         + "db?password=****&key1=value1&key2=value2&key3=value3&"
         + "user=smith&password=****&other=value"
     );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldStructUnsupported() throws SQLException {
+    Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
+    dialect.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldArrayUnsupported() throws SQLException {
+    Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldMapUnsupported() throws SQLException {
+    Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/OracleDatabaseDialectTest.java
@@ -19,14 +19,22 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDialect> {
 
@@ -235,5 +243,23 @@ public class OracleDatabaseDialectTest extends BaseDialectTest<OracleDatabaseDia
         "jdbc:oracle:thin:@myhost:1111/db?password=****&key1=value1&"
         + "key2=value2&key3=value3&user=smith&password=****&other=value"
     );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldStructUnsupported() throws SQLException {
+    Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
+    dialect.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldArrayUnsupported() throws SQLException {
+    Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldMapUnsupported() throws SQLException {
+    Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/PostgreSqlDatabaseDialectTest.java
@@ -19,16 +19,23 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collections;
 
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDatabaseDialect> {
 
@@ -288,5 +295,23 @@ public class PostgreSqlDatabaseDialectTest extends BaseDialectTest<PostgreSqlDat
         "jdbc:postgresql://localhost/test?user=fred&password=secret&ssl=true",
         "jdbc:postgresql://localhost/test?user=fred&password=****&ssl=true"
     );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldStructUnsupported() throws SQLException {
+    Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
+    dialect.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldArrayUnsupported() throws SQLException {
+    Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldMapUnsupported() throws SQLException {
+    Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SapHanaDatabaseDialectTest.java
@@ -19,16 +19,23 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
 
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class SapHanaDatabaseDialectTest extends BaseDialectTest<SapHanaDatabaseDialect> {
 
@@ -222,5 +229,23 @@ public class SapHanaDatabaseDialectTest extends BaseDialectTest<SapHanaDatabaseD
         "jdbc:sap://something?password=****&key1=value1&key2=value2&key3=value3&"
         + "user=smith&password=****&other=value"
     );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldStructUnsupported() throws SQLException {
+    Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
+    dialect.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldArrayUnsupported() throws SQLException {
+    Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldMapUnsupported() throws SQLException {
+    Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqlServerDatabaseDialectTest.java
@@ -19,14 +19,22 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
 import io.confluent.connect.jdbc.util.QuoteMethod;
 import io.confluent.connect.jdbc.util.TableId;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatabaseDialect> {
 
@@ -317,5 +325,23 @@ public class SqlServerDatabaseDialectTest extends BaseDialectTest<SqlServerDatab
         "jdbc:sqlserver://;password=****;servername=server_name;keyStoreSecret=****;"
         + "gsscredential=****;integratedSecurity=true;authenticationScheme=JavaKerberos"
     );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldStructUnsupported() throws SQLException {
+    Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
+    dialect.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldArrayUnsupported() throws SQLException {
+    Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldMapUnsupported() throws SQLException {
+    Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SqliteDatabaseDialectTest.java
@@ -19,15 +19,20 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -41,6 +46,7 @@ import io.confluent.connect.jdbc.util.TableId;
 
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDialect> {
 
@@ -304,5 +310,23 @@ public class SqliteDatabaseDialectTest extends BaseDialectTest<SqliteDatabaseDia
 
     assertTrue(differenceInTime < 5);
     assertTrue(matcher.matches());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldStructUnsupported() throws SQLException {
+    Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
+    dialect.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldArrayUnsupported() throws SQLException {
+    Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldMapUnsupported() throws SQLException {
+    Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/SybaseDatabaseDialectTest.java
@@ -16,12 +16,15 @@
 package io.confluent.connect.jdbc.dialect;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.time.ZoneOffset;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.List;
 import java.util.TimeZone;
 import java.util.concurrent.ThreadLocalRandom;
@@ -34,8 +37,11 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
 public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDialect> {
@@ -372,5 +378,23 @@ public class SybaseDatabaseDialectTest extends BaseDialectTest<SybaseDatabaseDia
         "jdbc:jtds:sybase://something?password=****&key1=value1&key2=value2&key3=value3&"
         + "user=smith&password=****&other=value"
     );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldStructUnsupported() throws SQLException {
+    Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
+    dialect.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldArrayUnsupported() throws SQLException {
+    Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldMapUnsupported() throws SQLException {
+    Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/dialect/VerticaDatabaseDialectTest.java
+++ b/src/test/java/io/confluent/connect/jdbc/dialect/VerticaDatabaseDialectTest.java
@@ -19,13 +19,21 @@ import org.apache.kafka.connect.data.Date;
 import org.apache.kafka.connect.data.Decimal;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Schema.Type;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.data.Time;
 import org.apache.kafka.connect.data.Timestamp;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Test;
 
 import io.confluent.connect.jdbc.util.QuoteMethod;
 
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Collections;
+
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
 
 public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseDialect> {
 
@@ -217,5 +225,23 @@ public class VerticaDatabaseDialectTest extends BaseDialectTest<VerticaDatabaseD
         "jdbc:vertica://something?password=****&key1=value1&key2=value2&key3=value3&"
         + "user=smith&password=****&other=value"
     );
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldStructUnsupported() throws SQLException {
+    Schema structSchema = SchemaBuilder.struct().field("test", Schema.BOOLEAN_SCHEMA).build();
+    dialect.bindField(mock(PreparedStatement.class), 1, structSchema, new Struct(structSchema));
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldArrayUnsupported() throws SQLException {
+    Schema arraySchema = SchemaBuilder.array(Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, arraySchema, Collections.emptyList());
+  }
+
+  @Test(expected = ConnectException.class)
+  public void bindFieldMapUnsupported() throws SQLException {
+    Schema mapSchema = SchemaBuilder.map(Schema.INT8_SCHEMA, Schema.INT8_SCHEMA);
+    dialect.bindField(mock(PreparedStatement.class), 1, mapSchema, Collections.emptyMap());
   }
 }

--- a/src/test/java/io/confluent/connect/jdbc/source/MockTime.java
+++ b/src/test/java/io/confluent/connect/jdbc/source/MockTime.java
@@ -59,7 +59,6 @@ public class MockTime implements Time {
         this.nanos += TimeUnit.NANOSECONDS.convert(ms, TimeUnit.MILLISECONDS);
     }
 
-    @Override
     public void waitObject(Object obj, Supplier<Boolean> condition, long timeoutMs) {
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
This PR adds:

- Support for CrateDB table structures with autogenerated tables
  including casting arrays to arrays and maps/structs to object columns.

- Support for inserting nested datatypes into CrateDB when read from
  Kafka.